### PR TITLE
Add error handler to log the error on scraping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN yarn build
 
 FROM builder AS dependencies
 WORKDIR /web-scraper-script
-COPY ["package.json", "yarn.lock", "./"]
+COPY ["package.json", "yarn.lock",  "./"]
 RUN yarn --prod
 
 

--- a/src/services/searchResult.ts
+++ b/src/services/searchResult.ts
@@ -1,19 +1,28 @@
 import Tag from '../models/Tags';
 import SearchResult, { SearchResultPayload } from '../models/SearchResult';
+
 import { loadSearchResults } from './scraper';
+
+import logger from '../utils/logger';
 
 export async function insertSearchResultForUserTags(userId: number) {
   const tags = await Tag.fetch(userId);
   for (const tag of tags) {
-    const queryResult = await loadSearchResults(tag.name);
-    const searchResultPayload: SearchResultPayload = {
-      ad_words_count: queryResult.adsLength,
-      total_results: queryResult.statResult,
-      links_count: queryResult.linksCount,
-      html_page: queryResult.htmlPage
-    };
+    try {
+      const queryResult = await loadSearchResults(tag.name);
+      const searchResultPayload: SearchResultPayload = {
+        ad_words_count: queryResult.adsLength,
+        total_results: queryResult.statResult,
+        links_count: queryResult.linksCount,
+        html_page: queryResult.htmlPage
+      };
 
-    let [searchResult] = await SearchResult.insertData(searchResultPayload);
-    await Tag.updateById(tag.id, { results_id: searchResult.id });
+      let [searchResult] = await SearchResult.insertData(searchResultPayload);
+      await Tag.updateById(tag.id, { results_id: searchResult.id });
+    } catch (err) {
+      //ToDo: add a logger table from where a separate service can load all the search result for failed ones
+      logger.error(err, `Error occurred for ${tag}`);
+      continue;
+    }
   }
 }


### PR DESCRIPTION
##  Description
Add a try catch to handle error on scraping result process so that if any error occurs process would not explode.
 However, in a more production ready code Ideal would be to log them on a log table and process the failed tags separately.
